### PR TITLE
Stephanie test

### DIFF
--- a/.buildkite/diff
+++ b/.buildkite/diff
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+[ $# -lt 1 ] && { echo "argument is missing."; exit 1; }
+
+COMMIT=$1
+
+BRANCH_POINT_COMMIT=$(git merge-base master $COMMIT)
+
+echo "diff between $COMMIT and $BRANCH_POINT_COMMIT"
+git --no-pager diff --name-only $COMMIT..$BRANCH_POINT_COMMIT

--- a/.buildkite/merge.yml
+++ b/.buildkite/merge.yml
@@ -1,0 +1,14 @@
+steps:
+  - label: "Triggering merge pipeline"
+    plugins:
+      chronotc/monorepo-diff#v1.1.1:
+        diff: "git diff --name-only HEAD~1"
+        wait: false
+        watch:
+          - path: "foo-service"
+            config:
+              trigger: "foo-service-merge"
+          - path: "bar-service"
+            config:
+              trigger: "bar-service-merge"
+

--- a/.buildkite/pipelines/deploy.json
+++ b/.buildkite/pipelines/deploy.json
@@ -1,0 +1,16 @@
+{
+  "name": "$PIPELINE_NAME",
+  "description": "Pipeline for $PIPELINE_NAME deploy",
+  "repository": "$REPOSITORY",
+  "default_branch": "master",
+  "steps": [
+    {
+      "type": "script",
+      "name": ":buildkite: $PIPELINE_TYPE",
+      "command": "buildkite-agent pipeline upload $SERVICE/.buildkite/$PIPELINE_TYPE.yml"
+    }
+  ],
+  "provider_settings": {
+    "trigger_mode": "none"
+  }
+}

--- a/.buildkite/pipelines/merge.json
+++ b/.buildkite/pipelines/merge.json
@@ -1,0 +1,22 @@
+{
+  "name": "$PIPELINE_NAME",
+  "description": "Pipeline for $PIPELINE_NAME merge",
+  "repository": "$REPOSITORY",
+  "default_branch": "master",
+  "steps": [
+    {
+      "type": "script",
+      "name": ":buildkite: $PIPELINE_TYPE",
+      "command": "buildkite-agent pipeline upload $SERVICE/.buildkite/$PIPELINE_TYPE.yml"
+    }
+  ],
+  "cancel_running_branch_builds": true,
+  "skip_queued_branch_builds": true,
+  "branch_configuration": "master",
+  "provider_settings": {
+    "trigger_mode": "code",
+    "build_pull_requests": false,
+    "publish_blocked_as_pending": true,
+    "publish_commit_status_per_step": true
+  }
+}

--- a/.buildkite/pipelines/pull-request.json
+++ b/.buildkite/pipelines/pull-request.json
@@ -1,0 +1,24 @@
+{
+  "name": "$PIPELINE_NAME",
+  "description": "Pipeline for $PIPELINE_NAME pull requests",
+  "repository": "$REPOSITORY",
+  "default_branch": "",
+  "steps": [
+    {
+      "type": "script",
+      "name": ":buildkite: $PIPELINE_TYPE",
+      "command": "buildkite-agent pipeline upload $SERVICE/.buildkite/$PIPELINE_TYPE.yml"
+    }
+  ],
+  "cancel_running_branch_builds": true,
+  "skip_queued_branch_builds": true,
+  "branch_configuration": "!master",
+  "provider_settings": {
+    "trigger_mode": "code",
+    "publish_commit_status_per_step": true,
+    "publish_blocked_as_pending": true,
+    "pull_request_branch_filter_enabled": true,
+    "pull_request_branch_filter_configuration": "!master",
+    "separate_pull_request_statuses": true
+  }
+}

--- a/.buildkite/pull-request.yml
+++ b/.buildkite/pull-request.yml
@@ -1,0 +1,14 @@
+steps:
+  - label: "Triggering pull request pipeline"
+    plugins:
+      chronotc/monorepo-diff#v1.1.1:
+        diff: ".buildkite/diff ${BUILDKITE_COMMIT}"
+        wait: false
+        watch:
+          - path: "foo-service"
+            config:
+              trigger: "foo-service-pull-request"
+          - path: "bar-service"
+            config:
+              trigger: "bar-service-pull-request"
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+
+# Created by https://www.gitignore.io/api/osx
+# Edit at https://www.gitignore.io/?templates=osx
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# End of https://www.gitignore.io/api/osx
+.env
+.envrc
+id_rsa*
+*.pub
+aws-stack.yml

--- a/README.md
+++ b/README.md
@@ -9,39 +9,39 @@ The monorepo, serves as a unified, version-controlled repository that houses mul
 
 * Reduce overhead associated with duplicating code for microservices.
 * Easily maintain and monitor the code
+ 
 
-
-<br/>  
 
 ## User Manual
 
-Create Folders and/or Sub folders in the repository to watch, we will be using `app/` and `test/` folders
+Directories Layout for the example repository
 
 ```
-├── .buildkite
-│   ├── pipelines
-├── app
-|   ├── .buildkite
-│   ├── bin
-├── bin
-├── test
-|   ├── .buildkite
-│   ├── bin
+├── .buildkite                          # Watch Folder
+│   ├── pipelines                       # Watch Folder
+├── app                                 # Watch Folder
+|   ├── .buildkite                      # Watch Folder
+│   ├── bin                             # Watch Folder
+├── bin                                 # Watch Folder
+├── test                                # Watch Folder
+|   ├── .buildkite                      # Watch Folder
+│   ├── bin                             # Watch Folder
 ├── .gitignore
 └── README.md
 
 ```
+Create Folders and/or Sub folders in the repository to watch.  Any directory in the repository can be watched  with the `watch` attribute and its `path`
 
-#### Webhooks
-
-Configure Webhooks in the Github Repository settings for your pipeline to subscribe to `Pushes`, `Deployments` and `Pull Requests` events. You must be a repository owner or have admin access in the repository to create webhooks.
-
+**Requirements**
+* Configure Webhooks in the Github Repository settings for your pipeline to subscribe to `Pushes`, `Deployments` and `Pull Requests` events. You must be a repository owner or have admin access in the repository to create webhooks.
 
 
-#### monorepo-diff-buildkite-plugin
-We would be using the buildkite monorepo-diff plugin, it will assist in triggering pipelines by watching folders in the monorepo. The configuration supports running [Command](https://buildkite.com/docs/pipelines/command-step) or [Triggering](https://buildkite.com/docs/pipelines/trigger-step)
+<br/>
 
-The user has to explictly state the paths they want to monitor. For example if a user specifies `app/` as the path and changes are made to `app/bin` it will not trigger the config because the subfolder was not specified.
+## Using the monorepo-diff-buildkite-plugin
+The  [**monorepo-diff buildkite plugin**](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin), assist in triggering pipelines by watching folders in the monorepo. The configuration supports running [Command](https://buildkite.com/docs/pipelines/command-step) and [Trigger](https://buildkite.com/docs/pipelines/trigger-step) steps
+
+⚠️  Warning : The user has to explictly state the paths they want to monitor. For instance if a user,  is only watching path `app/` changes made to `app/bin` will not trigger the configuration. This is because the subfolder `/bin` was not specified.
 
 
 <br/>
@@ -65,8 +65,8 @@ steps:
 ```
 
 
-* Changes to the path `app/` triggers the the pipeline `app-deploy`
-* Changes to the path `test/bin` will run the respectively config command
+* Changes to the path `app/` triggers the pipeline `app-deploy`
+* Changes to the path `test/bin` will run the respective configuration command
 
 <br/>
 
@@ -99,8 +99,8 @@ See [**How to set up Continuous Integration for monorepo using Buildkite**](http
                         release-version: "1.1"
 ```
 
-* When changes are detected in the path `test/.buildkite/`  it triggers the the pipeline `test-pipeline`
-* If the changes are made to either `app/` or `app/bin/service/` it triggers `data-generator`
+* When changes are detected in the path `test/.buildkite/`  it triggers the pipeline `test-pipeline`
+* If the changes are made to either `app/` or `app/bin/service/` it triggers the pipeline `data-generator`
 
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# monorepo-example
-This repository is an example Buildkite Mono Repo
+# buildkite-docker-example
+Source code for [How to set up Continuous Integration for monorepo using Buildkite](https://adikari.medium.com/set-up-continuous-integration-for-monorepo-using-buildkite-61539bb0ed76)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,111 @@
-# buildkite-docker-example
-Source code for [How to set up Continuous Integration for monorepo using Buildkite](https://adikari.medium.com/set-up-continuous-integration-for-monorepo-using-buildkite-61539bb0ed76)
+# Buildkite-Monorepo-Example
+
+
+
+[![Add to Buildkite](https://buildkite.com/button.svg)](https://buildkite.com/new)
+
+
+The monorepo, serves as a unified, version-controlled repository that houses multiple independent projects, giving you flexibility, easy management, and a simpler way to keep track of changes and dependencies across different repositories.
+
+* Reduce overhead associated with duplicating code for microservices.
+* Easily maintain and monitor the code
+
+
+<br/>  
+
+## User Manual
+
+Create Folders and/or Sub folders in the repository to watch, we will be using `app/` and `test/` folders
+
+```
+├── .buildkite
+│   ├── pipelines
+├── app
+|   ├── .buildkite
+│   ├── bin
+├── bin
+├── test
+|   ├── .buildkite
+│   ├── bin
+├── .gitignore
+└── README.md
+
+```
+
+#### Webhooks
+
+Configure Webhooks in the Github Repository settings for your pipeline to subscribe to `Pushes`, `Deployments` and `Pull Requests` events. You must be a repository owner or have admin access in the repository to create webhooks.
+
+
+
+#### monorepo-diff-buildkite-plugin
+We would be using the buildkite monorepo-diff plugin, it will assist in triggering pipelines by watching folders in the monorepo. The configuration supports running [Command](https://buildkite.com/docs/pipelines/command-step) or [Triggering](https://buildkite.com/docs/pipelines/trigger-step)
+
+The user has to explictly state the paths they want to monitor. For example if a user specifies `app/` as the path and changes are made to `app/bin` it will not trigger the config because the subfolder was not specified.
+
+
+<br/>
+
+**Example 1**
+<br/>
+
+```yaml
+steps:
+  - label: "Triggering pipelines"
+    plugins:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: app/
+              config:
+                trigger: "app-deploy"
+            - path: test/bin/
+              config:
+                command: "echo Make Changes to Bin"
+```
+
+
+* Changes to the path `app/` triggers the the pipeline `app-deploy`
+* Changes to the path `test/bin` will run the respectively config command
+
+<br/>
+
+See [**How to set up Continuous Integration for monorepo using Buildkite**](https://adikari.medium.com/set-up-continuous-integration-for-monorepo-using-buildkite-61539bb0ed76) for step-by-step instructions on how to get this running
+
+
+<br/>
+
+ **Example 2**
+ <br/>
+    
+
+```yaml
+    steps:
+      - label: "Triggering pipelines with plugin"
+        plugins:
+          - buildkite-plugins/monorepo-diff#v1.0.1:
+             watch:           
+              - path: test/.buildkite/
+                config: # Required [trigger step configuration]
+                  trigger: test-pipeline # Required [trigger pipeline slug]
+              - path:
+                  - app/
+                  - app/bin/service/
+                config:
+                    trigger: "data-generator"
+                    label: ":package: Generate data"
+                    build:
+                      meta_data:
+                        release-version: "1.1"
+```
+
+* When changes are detected in the path `test/.buildkite/`  it triggers the the pipeline `test-pipeline`
+* If the changes are made to either `app/` or `app/bin/service/` it triggers `data-generator`
+
+
+<br/>
+
+## License
+
+See [License.md](License.md) (MIT)
+

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 [![Add to Buildkite](https://buildkite.com/button.svg)](https://buildkite.com/new)
 
 
-The monorepo, serves as a unified, version-controlled repository that houses multiple independent projects, giving you flexibility, easy management, and a simpler way to keep track of changes and dependencies across different repositories.
+The monorepo allows users to house multiple independent projects in one repository, giving you flexibility, easy management, and a simpler way to keep track of changes by watching folders
 
-* Reduce overhead associated with duplicating code for microservices.
-* Easily maintain and monitor the code
- 
+## Setup
+To Get Started Fork the repository. Any directory in the repository can be watched  by specifying the `watch` attribute and its `path` in the pipeline configuration
 
+See [**How to set up Continuous Integration for monorepo using Buildkite**](https://adikari.medium.com/set-up-continuous-integration-for-monorepo-using-buildkite-61539bb0ed76) for step-by-step instructions
 
-## User Manual
+<br/>
 
-Directories Layout for the example repository
+**Project Directories Structure**
 
 ```
 ├── .buildkite                          # Watch Folder
@@ -30,78 +30,76 @@ Directories Layout for the example repository
 └── README.md
 
 ```
-Create Folders and/or Sub folders in the repository to watch.  Any directory in the repository can be watched  with the `watch` attribute and its `path`
 
-**Requirements**
-* Configure Webhooks in the Github Repository settings for your pipeline to subscribe to `Pushes`, `Deployments` and `Pull Requests` events. You must be a repository owner or have admin access in the repository to create webhooks.
+
+**Requirement**
+* Configure Webhooks in the Github Repository settings for your pipeline to subscribe to `Pushes`, `Deployments` and `Pull Requests` events. Can get the **Payload URL** from the pipeline's github settings setup instructions. If you don't have the permission, you'll need to get your repository admin to do this step. 
+
+
 
 
 <br/>
 
 ## Using the monorepo-diff-buildkite-plugin
-The  [**monorepo-diff buildkite plugin**](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin), assist in triggering pipelines by watching folders in the monorepo. The configuration supports running [Command](https://buildkite.com/docs/pipelines/command-step) and [Trigger](https://buildkite.com/docs/pipelines/trigger-step) steps
-
-⚠️  Warning : The user has to explictly state the paths they want to monitor. For instance if a user,  is only watching path `app/` changes made to `app/bin` will not trigger the configuration. This is because the subfolder `/bin` was not specified.
-
+The  [**monorepo-diff buildkite plugin**](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin), triggers pipelines by watching folders in the monorepo. The configuration supports running [Command](https://buildkite.com/docs/pipelines/command-step) and [Trigger](https://buildkite.com/docs/pipelines/trigger-step) steps
 
 <br/>
 
-**Example 1**
-<br/>
-
-```yaml
-steps:
-  - label: "Triggering pipelines"
-    plugins:
-      - buildkite-plugins/monorepo-diff#v1.0.1:
-          diff: "git diff --name-only HEAD~1"
-          watch:
-            - path: app/
-              config:
-                trigger: "app-deploy"
-            - path: test/bin/
-              config:
-                command: "echo Make Changes to Bin"
-```
-
-
-* Changes to the path `app/` triggers the pipeline `app-deploy`
-* Changes to the path `test/bin` will run the respective configuration command
-
-<br/>
-
-See [**How to set up Continuous Integration for monorepo using Buildkite**](https://adikari.medium.com/set-up-continuous-integration-for-monorepo-using-buildkite-61539bb0ed76) for step-by-step instructions on how to get this running
-
-
-<br/>
-
- **Example 2**
+ **Example 1**
  <br/>
-    
-
-```yaml
-    steps:
-      - label: "Triggering pipelines with plugin"
-        plugins:
-          - buildkite-plugins/monorepo-diff#v1.0.1:
-             watch:           
-              - path: test/.buildkite/
-                config: # Required [trigger step configuration]
-                  trigger: test-pipeline # Required [trigger pipeline slug]
-              - path:
-                  - app/
-                  - app/bin/service/
-                config:
-                    trigger: "data-generator"
-                    label: ":package: Generate data"
-                    build:
-                      meta_data:
-                        release-version: "1.1"
-```
-
-* When changes are detected in the path `test/.buildkite/`  it triggers the pipeline `test-pipeline`
-* If the changes are made to either `app/` or `app/bin/service/` it triggers the pipeline `data-generator`
-
+ 
+ ```yaml
+ steps:
+   - label: "Triggering pipelines"
+     plugins:
+       - buildkite-plugins/monorepo-diff#v1.0.1:
+           diff: "git diff --name-only HEAD~1"
+           watch:
+             - path: app/
+               config:
+                 trigger: "app-deploy"
+             - path: test/bin/
+               config:
+                 command: "echo Make Changes to Bin"
+ ```
+ 
+ 
+ * Changes to the path `app/` triggers the pipeline `app-deploy`
+ * Changes to the path `test/bin` will run the respective configuration command
+ 
+ <br/>
+ 
+ ⚠️  Warning : The user has to explictly state the paths they want to monitor. For instance if a user,  is only watching path `app/` changes made to `app/bin` will not trigger the configuration. This is because the subfolder `/bin` was not specified.
+ 
+ <br/>
+ 
+  **Example 2**
+  <br/>
+     
+ 
+ ```yaml
+     steps:
+       - label: "Triggering pipelines with plugin"
+         plugins:
+           - buildkite-plugins/monorepo-diff#v1.0.1:
+              watch:           
+               - path: test/.buildkite/
+                 config: # Required [trigger step configuration]
+                   trigger: test-pipeline # Required [trigger pipeline slug]
+               - path:
+                   - app/
+                   - app/bin/service/
+                 config:
+                     trigger: "data-generator"
+                     label: ":package: Generate data"
+                     build:
+                       meta_data:
+                         release-version: "1.1"
+ ```
+ 
+ * When changes are detected in the path `test/.buildkite/`  it triggers the pipeline `test-pipeline`
+ * If the changes are made to either `app/` or `app/bin/service/` it triggers the pipeline `data-generator`
+ 
 
 <br/>
 

--- a/app/.buildkite/deploy.yml
+++ b/app/.buildkite/deploy.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Deploying bar service to ${STAGE}"
+    command: "./bar-service/bin/deploy ${STAGE}"

--- a/app/.buildkite/merge.yml
+++ b/app/.buildkite/merge.yml
@@ -1,0 +1,22 @@
+steps:
+  - label: "Run sanity checks"
+    command:
+      - "echo linting"
+      - "echo testing"
+
+  - label: "Deploy to staging"
+    trigger: "bar-service-deploy"
+    build:
+      env:
+        STAGE: "staging"
+
+  - wait
+
+  - block: ":rocket: Release to Production"
+
+  - label: "Deploy to production"
+    trigger: "bar-service-deploy"
+    build:
+      env:
+        STAGE: "production"
+

--- a/app/.buildkite/pull-request.yml
+++ b/app/.buildkite/pull-request.yml
@@ -1,0 +1,5 @@
+steps:
+  - label: "Bar service pull request"
+    command:
+      - "echo linting"
+      - "echo testing"

--- a/app/bin/deploy
+++ b/app/bin/deploy
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+STAGE=$1
+
+echo "Deploying bar service to $STAGE."
+

--- a/bin/create-pipeline
+++ b/bin/create-pipeline
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export SERVICE="."
+export PIPELINE_TYPE=""
+export REPOSITORY=git@github.com:adikari/buildkite-docker-example.git
+
+CURRENT_DIR=$(pwd)
+ROOT_DIR="$( dirname "${BASH_SOURCE[0]}" )"/..
+STATUS_CHECK=false
+BUILDKITE_ORG_SLUG=adikari # update to your buildkite org slug
+
+USAGE="USAGE: $(basename "$0") [-s|--service] service_name [-t|--type] pipeline_type
+
+Eg: create-pipeline --type pull-request
+    create-pipeline --type merge --service foo-service
+    create-pipeline --type merge --status-checks
+
+NOTE: BUILDKITE_API_TOKEN must be set in environment
+
+ARGUMENTS:
+    -t | --type           buildkite pipeline type <merge|pull-request|deploy> (required)
+    -s | --service        service name (optional, default: deploy root pipeline)
+    -r | --repository     github repository url (optional, default: buildkite-docker-example)
+    -c | --status-checks      enable github status checks (optional, default: true)
+    -h | --help           show this help text"
+
+[ -z $BUILDKITE_API_TOKEN ] && { echo "BUILDKITE_API_TOKEN is not set."; exit 1;}
+
+while [ $# -gt 0 ]; do
+    if [[ $1 =~ "--"* ]]; then
+        case $1 in
+            --help|-h) echo "$USAGE"; exit; ;;
+            --service|-s) SERVICE=$2;;
+            --type|-t) PIPELINE_TYPE=$2;;
+            --repository|-r) REPOSITORY=$2;;
+            --status-check|-c) STATUS_CHECK=${2:-true};;
+        esac
+    fi
+    shift
+done
+
+[ -z "$PIPELINE_TYPE" ] && { echo "$USAGE"; exit 1; }
+
+export PIPELINE_NAME=$([ $SERVICE == "." ] && echo "" || echo "$SERVICE-")$PIPELINE_TYPE
+
+BUILDKITE_CONFIG_FILE=.buildkite/pipelines/$PIPELINE_TYPE.json
+[ ! -f "$BUILDKITE_CONFIG_FILE" ] && { echo "Invalid pipeline type: File not found $BUILDKITE_CONFIG_FILE"; exit; }
+
+BUILDKITE_CONFIG=$(cat $BUILDKITE_CONFIG_FILE | envsubst)
+
+if [ $STATUS_CHECK == "false" ]; then
+  pipeline_settings='{ "provider_settings": { "trigger_mode": "none" } }'
+  BUILDKITE_CONFIG=$((echo $BUILDKITE_CONFIG; echo $pipeline_settings) | jq -s add)
+fi
+
+cd $ROOT_DIR
+
+echo "Creating $PIPELINE_TYPE pipeline.."
+RESPONSE=$(curl -s POST "https://api.buildkite.com/v2/organizations/$BUILDKITE_ORG_SLUG/pipelines" \
+  -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  -d "$BUILDKITE_CONFIG"
+)
+
+[[ "$RESPONSE" == *errors* ]] && { echo $RESPONSE | jq; exit 1; }
+
+WEB_URL=$(echo $RESPONSE | jq -r '.web_url')
+WEBHOOK_URL=$(echo $RESPONSE | jq -r '.provider.webhook_url')
+
+echo "Pipeline url: $WEB_URL"
+echo "Webhook url: $WEBHOOK_URL"
+echo "$PIPELINE_NAME pipeline created."
+
+cd $CURRENT_DIR
+
+unset REPOSITORY
+unset PIPELINE_TYPE
+unset SERVICE
+unset PIPELINE_NAME

--- a/bin/create-secrets-bucket
+++ b/bin/create-secrets-bucket
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eou pipefail
+
+CURRENT_DIR=$(pwd)
+ROOT_DIR="$( dirname "${BASH_SOURCE[0]}" )"/..
+
+BUCKET_NAME="buildkite-secrets-adikari"
+KEY="id_rsa_buildkite"
+
+echo "creating bucket $BUCKET_NAME.."
+aws s3 mb s3://$BUCKET_NAME
+
+# Generate SSH Key
+ssh-keygen -t rsa -b 4096 -f $KEY -N ''
+
+# Copy SSH Keys to S3 bucket
+aws s3 cp --acl private --sse aws:kms $KEY "s3://$BUCKET_NAME/private_ssh_key"
+aws s3 cp --acl private --sse aws:kms $KEY.pub "s3://$BUCKET_NAME/public_key.pub"
+
+# Copy contents of public key to clipboard. Mac Only
+pbcopy < id_rsa_buildkite.pub
+echo "public key contents copied in clipboard."
+
+# Move SSH Keys to ~/.ssh directory
+mv ./$KEY* ~/.ssh
+chmod 600 ~/.ssh/$KEY
+chmod 644 ~/.ssh/$KEY.pub
+
+cd $CURRENT_DIR

--- a/bin/deploy-ci-stack
+++ b/bin/deploy-ci-stack
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+[ -z $BUILDKITE_AGENT_TOKEN ] && { echo "BUILDKITE_AGENT_TOKEN is not set."; exit 1;}
+
+CURRENT_DIR=$(pwd)
+ROOT_DIR="$( dirname "${BASH_SOURCE[0]}" )"/..
+PARAMETERS=$(cat ./bin/stack-config | envsubst)
+
+cd $ROOT_DIR
+
+echo "downloading elastic ci stack template.."
+curl -s https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.yml -O
+
+aws cloudformation deploy \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --template-file ./aws-stack.yml \
+  --stack-name "buildkite-elastic-ci" \
+  --parameter-overrides $PARAMETERS
+
+rm -f aws-stack.yml
+
+cd $CURRENT_DIR

--- a/bin/stack-config
+++ b/bin/stack-config
@@ -1,0 +1,7 @@
+BuildkiteAgentToken=$BUILDKITE_AGENT_TOKEN
+SecretsBucket=buildkite-secrets-adikari
+InstanceType=t2.micro
+MinSize=0
+MaxSize=3
+ScaleUpAdjustment=2
+ScaleDownAdjustment=-1

--- a/test/.buildkite/deploy.yml
+++ b/test/.buildkite/deploy.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Deploying foo service to ${STAGE}"
+    command: "./foo-service/bin/deploy ${STAGE}"

--- a/test/.buildkite/merge.yml
+++ b/test/.buildkite/merge.yml
@@ -1,0 +1,22 @@
+steps:
+  - label: "Run sanity checks"
+    command:
+      - "echo linting"
+      - "echo testing"
+
+  - label: "Deploy to staging"
+    trigger: "foo-service-deploy"
+    build:
+      env:
+        STAGE: "staging"
+
+  - wait
+
+  - block: ":rocket: Release to Production"
+
+  - label: "Deploy to production"
+    trigger: "foo-service-deploy"
+    build:
+      env:
+        STAGE: "production"
+

--- a/test/.buildkite/pull-request.yml
+++ b/test/.buildkite/pull-request.yml
@@ -1,0 +1,5 @@
+steps:
+  - label: "Foo service pull request"
+    command:
+      - "echo linting"
+      - "echo testing"

--- a/test/bin/deploy
+++ b/test/bin/deploy
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+STAGE=$1
+
+echo "Deploying foo service to $STAGE."
+


### PR DESCRIPTION
## Why?

The monorepo, a singular version-controlled repository containing diverse, independent projects, offers simplified management, and a reduction in the complexities of tracking changes and dependencies across multiple repositories


## How to Use

- Fork the [buildkite monorepo example](https://github.com/buildkite/monorepo-example/tree/stephanie-test)



## Using the monorepo-buildkite-plugin

[ monorepo-buildkite-plugin](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin)
- Use the following pipeline.yml 

   ``` yaml
    steps:
      - label: "Triggering pipelines"
        plugins:
          - buildkite-plugins/monorepo-diff#v1.0.1:
              diff: "git diff --name-only HEAD~1"
              watch:
                - path: "app/src"
                  config:
                    command: "echo Hello World"
                - path: "test/"
                  config:
                    trigger: "test-pipeline"
    ```

3.   Configure webhooks for the mono repo using the payload URL from the pipeline settings
4.   Make changes to the folders watched in your pipeline configuration

## Changes

- Added watch Folders (https://github.com/buildkite/monorepo-example/pull/2/commits/397fbd51c3437044e4ecd95d3b8269ae2402f476)

- Updated README.md (https://github.com/buildkite/monorepo-example/pull/2/commits/838dce23591de2546d07d3f77a8fa81d893f7d09)
