### PR TITLE
Fix Monorepo Pipeline Example

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,7 @@
 steps:
   - label: "Detect changed projects"
+    key: diff
+    soft_fail: true
     plugins:
       - monorepo-diff#v1.3.0:
           diff: .buildkite/scripts/git-diff-files.sh

--- a/.buildkite/scripts/git-diff-files.sh
+++ b/.buildkite/scripts/git-diff-files.sh
@@ -6,7 +6,7 @@ COMMIT="${BUILDKITE_COMMIT:-}"
 BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
 
 if [[ -z "$COMMIT" ]]; then
-  echo "Missing BUILDKITE_COMMIT env var"
+  echo "❌ Missing BUILDKITE_COMMIT env var"
   exit 1
 fi
 
@@ -14,5 +14,23 @@ BRANCH_POINT_COMMIT=$(git merge-base "$BASE_BRANCH" "$COMMIT")
 
 echo "⚙️ Diff between $COMMIT and $BRANCH_POINT_COMMIT"
 
-git --no-pager diff --name-only "$BRANCH_POINT_COMMIT".."$COMMIT" | \
-  grep -Ev '^\.buildkite/|\.md$|^README\.md$|^LICENSE$'
+CHANGED_FILES=$(git --no-pager diff --name-only "$BRANCH_POINT_COMMIT".."$COMMIT" | \
+  grep -Ev '^\.buildkite/|\.md$|^README\.md$|^LICENSE$' || true)
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "✅ No changes detected!"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "No triggering of pipelines was necessary."
+  echo ""
+  buildkite-agent annotate "✅ No changes detected - no pipelines triggered." --style "info"
+  exit 0
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🚀 Changes detected in:"
+echo "$CHANGED_FILES"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""

--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ This repository contains:
 
 Each sub-pipeline is triggered when files within its folder change.
 
+## First time running this?
 
+If you trigger a build without making changes to `service-app/` or `test/`, you’ll see:
+
+- A ✅ green build
+- A message at the top of the build (in the **Annotations** tab) saying:
+  _“No changes detected - no pipelines triggered.”_
+
+This is expected! The root pipeline uses the [`monorepo-diff`](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin) plugin to only trigger pipelines when changes are detected in watched folders.
+
+> 💡 **Tip:** To test it out, try committing a small change inside `service-app/` or `test/`.
 
 ## Setup
 

--- a/test/bin/deploy
+++ b/test/bin/deploy
@@ -4,5 +4,5 @@ set -euo pipefail
 
 STAGE=$1
 
-echo "Deploying foo service to $STAGE. test diff"
+echo "Deploying foo service to $STAGE."
 

--- a/test/bin/deploy
+++ b/test/bin/deploy
@@ -4,5 +4,5 @@ set -euo pipefail
 
 STAGE=$1
 
-echo "Deploying foo service to $STAGE."
+echo "Deploying foo service to $STAGE. test diff"
 


### PR DESCRIPTION
This example uses the monorepo diff plugin to trigger builds if changes are detected within the `service-app` repo or the `test` repo

If no changes were detected and the plugin didn't run, it did not fail gracefully.
<img width="1557" height="1017" alt="image" src="https://github.com/user-attachments/assets/857c94c7-ff0c-4fa3-a23a-0a1df58a63a9" />


## Changes

If the monorepo main pipeline example runs but no changes are detected, I modified the `git-diff-files.sh` to add an annotation (trying to make it echo in the logs via yaml was a bit tricky)
<img width="859" height="234" alt="image" src="https://github.com/user-attachments/assets/e784358b-f14e-41d7-b346-382fb5cf2f99" />

I also updated the README to clearly highlight this behaviour
<img width="906" height="313" alt="image" src="https://github.com/user-attachments/assets/eff582cf-7ec0-4848-bc05-de181d169e76" />

