### PR TITLE
Update links to main pipeline and latest test pipeline build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the full [Getting Started Guide](https://buildkite.com/docs/guides/getting-s
 </a>
 <p align="left"><i>Root pipeline: detects changed folders and triggers service/test pipelines</i></p>
 
-<a href="https://buildkite.com/buildkite/monorepo-service-app-example/builds/latest?branch=main">
+<a href="https://buildkite.com/buildkite/monorepo-service-app-example/builds/latest">
   <img width="2400" alt="Screenshot of service-app pipeline" src=".buildkite/screenshot-2.png" />
 </a>
 <p align="left"><i>Service App pipeline: triggered by changes to <code>service-app/</code></i></p>

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This repository demonstrates a [Buildkite](https://buildkite.com/) setup for man
 
 👉 **See these examples in action:**
 
-- [Root pipeline](https://buildkite.com/buildkite/monorepo-example/builds/latest?branch=main) - detects changes and triggers other pipelines
+- [Root pipeline](https://buildkite.com/buildkite/monorepo-main-example/builds/latest?branch=main) - detects changes and triggers other pipelines
 - [Service App pipeline](https://buildkite.com/buildkite/monorepo-service-app-example/builds/latest?branch=main) - runs `service-app` pipeline
 - [Test pipeline](https://buildkite.com/buildkite/monorepo-test-example/builds/latest?branch=main) - runs `test` pipeline
 
 See the full [Getting Started Guide](https://buildkite.com/docs/guides/getting-started) and [**How to set up Continuous Integration for a monorepo using Buildkite**](https://adikari.medium.com/set-up-continuous-integration-for-monorepo-using-buildkite-61539bb0ed76) for step-by-step instructions on how to get this running.
 
-<a href="https://buildkite.com/buildkite/monorepo-example/builds/latest?branch=main">
+<a href="https://buildkite.com/buildkite/monorepo-main-example/builds/latest?branch=main">
   <img width="2400" alt="Screenshot of the root monorepo pipeline" src=".buildkite/screenshot-1.png" />
 </a>
 <p align="left"><i>Root pipeline: detects changed folders and triggers service/test pipelines</i></p>
@@ -20,7 +20,7 @@ See the full [Getting Started Guide](https://buildkite.com/docs/guides/getting-s
 </a>
 <p align="left"><i>Service App pipeline: triggered by changes to <code>service-app/</code></i></p>
 
-<a href="https://buildkite.com/buildkite/monorepo-test-example/builds/latest?branch=main">
+<a href="https://buildkite.com/buildkite/monorepo-test-example/builds/latest">
   <img width="2400" alt="Screenshot of test pipeline" src=".buildkite/screenshot-3.png" />
 </a>
 <p align="left"><i>Test pipeline: triggered by changes to <code>test/</code></i></p>
@@ -164,4 +164,3 @@ This pipeline will run whenever changes are detected in the `test/` folder.
 
 ## License
 See [LICENSE.md](LICENSE.md) (MIT)
-


### PR DESCRIPTION
The main pipeline was renamed in Buildkite - the existing links would've redirected but might as well update them here. Also fixes the link to the latest build on the `monorepo-test-example` - it was filtering to `branch=main` but that pipeline doesn't have builds on `main`.
